### PR TITLE
Add BibTeX export for profile publications

### DIFF
--- a/src/Lifiometro/CenterReportComponent.class.st
+++ b/src/Lifiometro/CenterReportComponent.class.st
@@ -430,15 +430,24 @@ CenterReportComponent >> renderPublicationsPlotOn: html [
 { #category : #'rendering-publications' }
 CenterReportComponent >> renderPublicationsReportOn: html [
 
-	article checked | inbook checked | inproceedings checked | book checked | misc checked ifFalse: [ ^ self ].
-	html heading
-		level1;
-		id: 'publications';
-		with: 'Publicaciones'.
-	self renderPublicationsPlotOn: html.
-	article checked ifTrue: [ self renderArticlePublicationsReportOn: html ].
-	inproceedings checked ifTrue: [
-		self renderInProceedingsPublicationsReportOn: html ].
+        article checked | inbook checked | inproceedings checked | book checked | misc checked ifFalse: [ ^ self ].
+        html heading
+                level1;
+                id: 'publications';
+                with: [
+                        html text: 'Publicaciones '.
+                        html anchor
+                                callback: [ self exportBibtex ];
+                                with: [ | iconTag |
+                                        iconTag := html tbsGlyphIcon.
+                                        iconTag iconFile.
+                                        iconTag with: [ html span
+                                                        style: 'position: absolute; bottom: 1px; left: 1px; font-size: 8px; color: white; font-weight: bold; background: transparent; padding: 0 0; border-radius: 0;';
+                                                        with: 'bib' ] ] ].
+        self renderPublicationsPlotOn: html.
+        article checked ifTrue: [ self renderArticlePublicationsReportOn: html ].
+        inproceedings checked ifTrue: [
+                self renderInProceedingsPublicationsReportOn: html ].
 	inbook checked ifTrue: [ self renderInBookPublicationsReportOn: html ].
 	book checked ifTrue: [ self renderBookPublicationsReportOn: html ].
 	misc checked ifTrue: [ self renderOtherPublicationsReportOn: html ]
@@ -744,9 +753,25 @@ CenterReportComponent >> toggleShowSummaries [
 { #category : #hooks }
 CenterReportComponent >> updateRoot: aWARoot [
 
-	super updateRoot: aWARoot.
-	aWARoot meta
-		name: 'viewport';
-		content: 'width=device-width, initial-scale=1'.
-	aWARoot title: 'LIFIA - Memoria técnica'
+        super updateRoot: aWARoot.
+        aWARoot meta
+                name: 'viewport';
+                content: 'width=device-width, initial-scale=1'.
+        aWARoot title: 'LIFIA - Memoria técnica'
+]
+
+{ #category : #actions }
+CenterReportComponent >> exportBibtex [
+       | bibtexEntries |
+       bibtexEntries := report allPublications
+                               select: [ :each | each class = BibtexReference ].
+       self requestContext respond: [ :response |
+               response contentType: 'application/x-bibtex'.
+               response headerAt: 'Content-Disposition'
+                               put: 'attachment; filename="publications.bib"'.
+               response nextPutAll:
+                       (String streamContents: [ :stream |
+                               bibtexEntries do: [ :each |
+                                       stream nextPutAll: each bibtexEntry printString;
+                                               cr; cr ] ]) ]
 ]

--- a/src/Lifiometro/GeneralReport.class.st
+++ b/src/Lifiometro/GeneralReport.class.st
@@ -246,6 +246,11 @@ GeneralReport >> years: theYears projects: theProjects publications: thePublicat
 		                       each level = 'Undergraduate' ].
 	phdThesis := theThesis select: [ :each | each level = 'PhD' ].
 	mastersThesis := theThesis select: [ :each | each level = 'Masters' ].
-	specializationThesis := theThesis select: [ :each |
-		                        each level = 'Specialization' ]
+        specializationThesis := theThesis select: [ :each |
+                                        each level = 'Specialization' ]
+]
+
+{ #category : #accessing }
+GeneralReport >> allPublications [
+        ^ articlePublications , inproceedingsPublications , inbookPublications , bookPublications , otherPublications
 ]

--- a/src/Lifiometro/IndividualReport.class.st
+++ b/src/Lifiometro/IndividualReport.class.st
@@ -50,5 +50,10 @@ IndividualReport >> scholarships [
 
 { #category : #accessing }
 IndividualReport >> thesis [
-	^ thesis
+        ^ thesis
+]
+
+{ #category : #accessing }
+IndividualReport >> allPublications [
+        ^ publications
 ]

--- a/src/Lifiometro/ProfileReportComponent.class.st
+++ b/src/Lifiometro/ProfileReportComponent.class.st
@@ -99,12 +99,23 @@ ProfileReportComponent >> renderPublications: aCollectionOfPublications withYear
 { #category : #rendering }
 ProfileReportComponent >> renderPublicationsOn: html [
 
-	| publications |
-	html heading level2 with: 'Publicaciones'.
-	publications := OrderedCollection new
-		                add:
-			                'Publicaciones en revistas'
-			                -> report articlePublications;
+       | publications |
+       html heading
+               level2;
+               with: [
+                       html text: 'Publicaciones '.
+                       html anchor
+                               callback: [ self exportBibtex ];
+                               with: [ | iconTag |
+                                       iconTag := html tbsGlyphIcon.
+                                       iconTag iconFile.
+                                       iconTag with: [ html span
+                                                       style: 'position: absolute; bottom: 1px; left: 1px; font-size: 8px; color: white; font-weight: bold; background: transparent; padding: 0 0; border-radius: 0;';
+                                                       with: 'bib' ] ] ].
+       publications := OrderedCollection new
+                               add:
+                                       'Publicaciones en revistas'
+                                       -> report articlePublications;
 		                add:
 			                'Publicaciones en conferencias'
 			                -> report inproceedingsPublications;
@@ -262,9 +273,25 @@ ProfileReportComponent >> titleForThesisSection [
 { #category : #rendering }
 ProfileReportComponent >> updateRoot: aWARoot [
 
-	super updateRoot: aWARoot.
-	aWARoot title: 'Memorias - LIFIA'.
-	aWARoot meta
-		name: 'viewport';
-		content: 'width=device-width, initial-scale=1'
+        super updateRoot: aWARoot.
+        aWARoot title: 'Memorias - LIFIA'.
+        aWARoot meta
+                name: 'viewport';
+                content: 'width=device-width, initial-scale=1'
+]
+
+{ #category : #actions }
+ProfileReportComponent >> exportBibtex [
+       | bibtexEntries |
+       bibtexEntries := report allPublications
+                               select: [ :each | each class = BibtexReference ].
+       self requestContext respond: [ :response |
+               response contentType: 'application/x-bibtex'.
+               response headerAt: 'Content-Disposition'
+                               put: 'attachment; filename="publications.bib"'.
+               response nextPutAll:
+                       (String streamContents: [ :stream |
+                               bibtexEntries do: [ :each |
+                                       stream nextPutAll: each bibtexEntry printString;
+                                               cr; cr ] ]) ]
 ]


### PR DESCRIPTION
## Summary
- add `allPublications` helper to reports
- allow profile components to export publications as a BibTeX file
- expose export link in publications sections of profile pages

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_684733b8f510832f8600b60683249c6d